### PR TITLE
Small changes to fix adding creating users.

### DIFF
--- a/backend/controllers/users.rb
+++ b/backend/controllers/users.rb
@@ -48,7 +48,8 @@ class ArchivesSpaceService < Sinatra::Base
 #     Use the (backend) lambdas to pull the information we need from stv.user_info.
       uid      = AppConfig[:omniauthCas][:backendUidProc].call(stv.user_info)
       email    = AppConfig[:omniauthCas][:backendEmailProc].call(stv.user_info)
-      logger.debug("omniauthCas/backend:           uid='#{uid}'")####
+      
+      ## logger.debug("omniauthCas/backend:           #{stv.user_info.inspect}")####
 #     If true, the authenticated user doesn't match the user the
 #     frontend authenticated.
       if (params[:username].casecmp(uid) != 0)
@@ -56,7 +57,7 @@ class ArchivesSpaceService < Sinatra::Base
       end
 
       json_user = JSONModel(:user).from_hash(:username => uid,
-                                             :name     => stv.user_info['name'],
+                                             :name     => stv.user_info['name'] || uid,
                                              :email    => email)
 
 #     From backend/app/model/authentication_manager.rb:

--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -3,6 +3,8 @@
 require 'aspace_logger'
 require 'omniauth-cas'
 
+include JSONModel
+
 begin
 
   logger = ASpaceLogger.new($stderr);
@@ -17,9 +19,10 @@ begin
   if ((initUserInfo = AppConfig[:omniauthCas][:initialUser]) &&
         !(initialUser = User.find(:username => initUserInfo[:username])))
 #   Create our initial user.
-    initialUser = JSONModel(:user).from_hash('username' => initUserInfo[:username],
+    
+    initialUser = User.create_from_json( JSONModel(:user).from_hash('username' => initUserInfo[:username],
                                              'name'     => initUserInfo[:name],
-                                             'is_admin' => true)
+                                             'is_admin' => true) )
     logger.info("omniauthCas/backend: initialUser='#{initialUser}'")####
   end
 


### PR DESCRIPTION
This makes sure the the init user feature working in the backend plugin_init on
v1.5.

Also makes the user name = uid if there is not a user name value present in the
response from CAS.