### PR TITLE
LIBASPACE-72 Update to work with aspace 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ ASpaceGems.setup if defined? ASpaceGems
 
 source 'http://rubygems.org'
 
-gem 'omniauth', '~> 1.2.0', :require => false
-gem 'hashie', '>= 1.2', '< 4', :require => false
-gem 'omniauth-cas', '~> 1.1.0', :require => false
-gem 'addressable', '>=2.3.0','<=2.4.0', :require => false
+gem 'omniauth', '~> 1.6.1', :require => false
+gem 'hashie', '~> 3.5.5', :require => false
+gem 'omniauth-cas', '~> 1.1.1', :require => false
+gem 'addressable', '~> 2.5.1', :require => false

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -12,4 +12,4 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 myRoutes = [ File.join(File.dirname(__FILE__), "routes.rb") ]
-ArchivesSpace::Application.config.paths['config/routes'].concat(myRoutes)
+ArchivesSpace::Application.extend_aspace_routes(File.join(File.dirname(__FILE__), "routes.rb"))


### PR DESCRIPTION
This updates the aspace omniauth cas plugin to work with aspace 2.0.1.
Bump omniauth and change a method to work with Rails 5